### PR TITLE
Remove release pinning

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-beautifulsoup4==4.6.1
-gevent==1.3.5
-greenlet==0.4.14
-requests==2.18.4
-selenium==3.14.0
-tldextract==2.2.0
-urllib3==1.22
-argh==0.26.2
+beautifulsoup4
+gevent
+greenlet
+requests
+selenium
+tldextract
+urllib3
+argh


### PR DESCRIPTION
The releases are out-dated and break the installation. At least Fedora ships already newer releases.